### PR TITLE
Create tasks for env creation and dependency sync

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,10 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/sshd:1": {}
     },
-    "postCreateCommand": "uv sync",
+    "postCreateCommand": {
+        "sync-uv": "uv sync --frozen",
+        "create-dummy-env": "bash scripts/create_env_file.sh"
+    },
     "shutdownAction": "stopContainer",
     "containerEnv": {
         "PYTHONPATH": "${containerWorkspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Resync Dependencies",
+            "type": "shell",
+            "command": [
+                "uv sync;",
+                "uv pip compile pyproject.toml -o requirements.txt;"
+            ],
+            "presentation": {
+                "echo": false,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Create .env file",
+            "type": "shell",
+            "command": "bash scripts/create_env_file.sh",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        }
+    ]
+}

--- a/scripts/create_env_file.sh
+++ b/scripts/create_env_file.sh
@@ -1,0 +1,1 @@
+! [ -f ".env" ] && echo "EXAMPLE_KEY=example_value" > .env || exit 0


### PR DESCRIPTION
This would address two problems:
- Auto-creating a sample `.env` file when it doesn't exist
- Create a new task to sync dependencies before rebuild