### PR TITLE
Remove uv.lock in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,7 +39,6 @@ saved_model/**/* filter=lfs diff=lfs merge=lfs -text
 *.zst filter=lfs diff=lfs merge=lfs -text
 *tfevents* filter=lfs diff=lfs merge=lfs -text
 data/**/* filter=lfs diff=lfs merge=lfs -text
-uv.lock filter=lfs diff=lfs merge=lfs -text
 
 # To avoid Linguist including .ipynb files in repository language breakdown
 # because notebooks are known to have huge filesizes.


### PR DESCRIPTION
I realized that adding this lockfile in LFS messes up any updates to the lockfile and it's better to have it removed in LFS.