### PR TITLE
Add PreToolUse hook and project-level deny list

### DIFF
--- a/.claude/hooks/pre_bash_check.sh
+++ b/.claude/hooks/pre_bash_check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse: enforce project tooling constraints before bash commands run.
+# Exit 0 = allow, exit 2 = block (stderr shown to Claude).
+
+input=$(cat)
+command=$(echo "$input" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+# Enforce uv over pip
+if echo "$command" | grep -qE '(^|[;&|]\s*)(pip|pip3)\s'; then
+    echo "Use 'uv run pip' or 'uv add' instead of pip directly (see .claude/rules/package-management.md)" >&2
+    exit 2
+fi
+
+# Enforce podman over docker
+if echo "$command" | grep -qE '(^|[;&|]\s*)docker\s'; then
+    echo "Use 'podman' instead of 'docker' (project convention)" >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pre_bash_check.sh
+++ b/.claude/hooks/pre_bash_check.sh
@@ -15,10 +15,4 @@ if echo "$command" | grep -qE '(^|[;&|]\s*)(pip|pip3)\s'; then
     exit 2
 fi
 
-# Enforce podman over docker
-if echo "$command" | grep -qE '(^|[;&|]\s*)docker\s'; then
-    echo "Use 'podman' instead of 'docker' (project convention)" >&2
-    exit 2
-fi
-
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,23 @@
 {
+    "permissions": {
+        "deny": [
+            "Bash(pip:*)",
+            "Bash(pip3:*)",
+            "Bash(conda:*)"
+        ]
+    },
     "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash .claude/hooks/pre_bash_check.sh"
+                    }
+                ]
+            }
+        ],
         "PostToolUse": [
             {
                 "matcher": "Write|Edit|MultiEdit",


### PR DESCRIPTION
Adds pre_bash_check.sh to catch pip/pip3 and docker usage before commands run. Wires it into settings.json as a PreToolUse:Bash hook. Also adds a permissions deny list for pip, pip3, and conda to enforce uv as the sole package manager at the project level.