### PR TITLE
Ignore .local/ directories in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ docs/superpowers/*
 
 # Internal Settings
 **/*.local.*
+**/.local/
 
 # Git Worktrees
 .worktrees/


### PR DESCRIPTION
Adds `**/.local/` alongside the existing `**/*.local.*` pattern under Internal Settings.
